### PR TITLE
feat: Add apns-expiration header to push notification request

### DIFF
--- a/main.js
+++ b/main.js
@@ -479,6 +479,7 @@ class APNs {
                 method: 'POST',
                 headers: {
                     'apns-topic': TOPIC,
+                    'apns-expiration': Math.floor(Date.now() / 1000) + 86400,
                     'apns-push-type': 'alert',
                     'authorization': `bearer ${AUTHENTICATION_TOKEN}`,
                     'content-type': 'application/json',

--- a/main_kv.js
+++ b/main_kv.js
@@ -479,6 +479,7 @@ class APNs {
                 method: 'POST',
                 headers: {
                     'apns-topic': TOPIC,
+                    'apns-expiration': Math.floor(Date.now() / 1000) + 86400,
                     'apns-push-type': 'alert',
                     'authorization': `bearer ${AUTHENTICATION_TOKEN}`,
                     'content-type': 'application/json',


### PR DESCRIPTION
https://github.com/Finb/bark-server/blob/969c4daa6b63dca7d76565e4bc906d5bb215d1b4/apns/apns.go#L121

Fixed the problem of messages not being stored in apns. It is now possible to receive notifications during shutdown after the phone is restored.


I forgot to change main.js in the last PR, sorry.